### PR TITLE
Fix a missing method name.

### DIFF
--- a/firebird/operations.py
+++ b/firebird/operations.py
@@ -282,7 +282,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             return []
 
     def drop_sequence_sql(self, table):
-        return 'DROP SEQUENCE %s' % self.get_generator_name(table)
+        return 'DROP SEQUENCE %s' % self.get_sequence_name(table)
 
     def get_sequence_name(self, table_name):
         return get_autoinc_sequence_name(self, table_name)


### PR DESCRIPTION
I just stumbled upon a small error when trying to nuke my Firebird database with South:

```
$ manage.py migrate SouthRest zero

Running migrations for SouthRest:
 - Migrating backwards to zero state.
 < SouthRest:0004_hash_names
 < SouthRest:0003_auto__add_field_knight_hash
 < SouthRest:0002_auto__add_field_knight_data
 < SouthRest:0001_initial
Error in migration: SouthRest:0001_initial
AttributeError: 'DatabaseOperations' object has no attribute 'get_generator_name'
```

This small change fixes it. :-)
