### PR TITLE
Removed unused DatabaseFeatures.can_introspect_max_length.

### DIFF
--- a/tests/test_main/inspectdb/tests.py
+++ b/tests/test_main/inspectdb/tests.py
@@ -46,34 +46,25 @@ class InspectDBTestCase(TestCase):
         assertFieldType = self.make_field_type_asserter()
 
         # Inspecting Oracle DB doesn't produce correct results (#19884):
-        # - it gets max_length wrong: it returns a number of bytes.
         # - it reports fields as blank=True when they aren't.
-        if (connection.features.can_introspect_max_length and
-                not connection.features.interprets_empty_strings_as_nulls):
+        if not connection.features.interprets_empty_strings_as_nulls:
             assertFieldType('char_field', "models.CharField(max_length=10)")
             assertFieldType('null_char_field', "models.CharField(max_length=10, blank=True, null=True)")
             assertFieldType('comma_separated_int_field', "models.CharField(max_length=99)")
-        assertFieldType('date_field', "models.DateField()")
-        assertFieldType('date_time_field', "models.DateTimeField()")
-        if (connection.features.can_introspect_max_length and
-                not connection.features.interprets_empty_strings_as_nulls):
             assertFieldType('email_field', "models.CharField(max_length=254)")
             assertFieldType('file_field', "models.CharField(max_length=100)")
             assertFieldType('file_path_field', "models.CharField(max_length=100)")
+            assertFieldType('slug_field', "models.CharField(max_length=50)")
+            assertFieldType('text_field', "models.TextField()")
+        assertFieldType('date_field', "models.DateField()")
+        assertFieldType('date_time_field', "models.DateTimeField()")
         if connection.features.can_introspect_ip_address_field:
             assertFieldType('gen_ip_adress_field', "models.GenericIPAddressField()")
-        elif (connection.features.can_introspect_max_length and
-                not connection.features.interprets_empty_strings_as_nulls):
+        elif not connection.features.interprets_empty_strings_as_nulls:
             assertFieldType('gen_ip_adress_field', "models.CharField(max_length=39)")
-        if (connection.features.can_introspect_max_length and
-                not connection.features.interprets_empty_strings_as_nulls):
-            assertFieldType('slug_field', "models.CharField(max_length=50)")
-        if not connection.features.interprets_empty_strings_as_nulls:
-            assertFieldType('text_field', "models.TextField()")
         if connection.features.can_introspect_time_field:
             assertFieldType('time_field', "models.TimeField()")
-        if (connection.features.can_introspect_max_length and
-                not connection.features.interprets_empty_strings_as_nulls):
+        if not connection.features.interprets_empty_strings_as_nulls:
             assertFieldType('url_field', "models.CharField(max_length=200)")
 
     def test_number_field_types(self):

--- a/tests/test_main/introspection/tests.py
+++ b/tests/test_main/introspection/tests.py
@@ -85,9 +85,6 @@ class IntrospectionTests(TransactionTestCase):
              'SmallIntegerField' if connection.features.can_introspect_small_integer_field else 'IntegerField']
         )
 
-    # The following test fails on Oracle due to #17202 (can't correctly
-    # inspect the length of character columns).
-    @skipUnlessDBFeature('can_introspect_max_length')
     def test_get_table_description_col_lengths(self):
         with connection.cursor() as cursor:
             desc = connection.introspection.get_table_description(cursor, Reporter._meta.db_table)


### PR DESCRIPTION
Unused (always True) (see [3e43d24](https://github.com/django/django/commit/3e43d24ad36d45cace57e6a7efd34638577ae74) and [PR](https://github.com/django/django/pull/7712)).