### PR TITLE
Database charset ignored when reading text fields

### DIFF
--- a/firebird/operations.py
+++ b/firebird/operations.py
@@ -236,7 +236,7 @@ class DatabaseOperations(BaseDatabaseOperations):
                 if connection.get_connection_params()['charset'] in charset_map:
                     db_charset = charset_map[connection.get_connection_params()['charset']]
             if db_charset:
-                value = force_text(value, encoding=charset, errors='replace')
+                value = force_text(value, encoding=db_charset, errors='replace')
             else:
                 value = force_text(value)
         return value


### PR DESCRIPTION
I was getting a DjangoUnicodeDecodeError when reading from a text field because my database uses cp1252 encoding (WIN1252). This update attempts to determine the database character set encoding and then use that to decode the data for text fields.

Two notes: (1) The default encoding is utf-8 which fails for certain cp1252 character codes. (2) The tests assume a utf-8 database.