### PR TITLE
Fix DjangoUnicodeDecodeError reading text field

### DIFF
--- a/firebird/operations.py
+++ b/firebird/operations.py
@@ -9,6 +9,7 @@ from django.utils.functional import cached_property
 from django.utils import six
 from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text
+from fdb.ibase import charset_map
 
 from .base import Database
 
@@ -230,7 +231,14 @@ class DatabaseOperations(BaseDatabaseOperations):
         if isinstance(value, Database.BlobReader):
             value = value.read()
         if value is not None:
-            value = force_text(value)
+            db_charset = None
+            if 'charset' in connection.get_connection_params():
+                if connection.get_connection_params()['charset'] in charset_map:
+                    db_charset = charset_map[connection.get_connection_params()['charset']]
+            if db_charset:
+                value = force_text(value, encoding=db_charset, errors='replace')
+            else:
+                value = force_text(value)
         return value
 
     def convert_binaryfield_value(self, value, expression, connection, context):


### PR DESCRIPTION
Same as main branch as my other pull request but for the 1.11.x branch.

My database uses cp1252 and I get DjangoUnicodeDecodeError exceptions when certain characters are encountered. The code changes fix these errors in my case.