### PR TITLE
Django 2.2 and and Firebird 3 support

### DIFF
--- a/firebird/__init__.py
+++ b/firebird/__init__.py
@@ -1,6 +1,6 @@
 from .version import get_version
 
-VERSION = (2, 0, 0, 'alpha', 0)
+VERSION = (2, 2, 10, 'alpha', 0)
 
 __version__ = get_version(VERSION)
 

--- a/firebird/base.py
+++ b/firebird/base.py
@@ -48,7 +48,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'AutoField': 'integer',
         'BigAutoField': 'bigint',
         'BinaryField': 'blob sub_type 0',
-        'BooleanField': 'smallint',
+        'BooleanField': 'smallint', # for firebird 3 it changes in init_connection_state
         'CharField': 'varchar(%(max_length)s)',
         'CommaSeparatedIntegerField': 'varchar(%(max_length)s)',
         'DateField': 'date',
@@ -62,7 +62,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'BigIntegerField': 'bigint',
         'IPAddressField': 'char(15)',
         'GenericIPAddressField': 'char(39)',
-        'NullBooleanField': 'smallint',
+        'NullBooleanField': 'smallint', # for firebird 3 it changes in init_connection_state
         'OneToOneField': 'integer',
         'PositiveIntegerField': 'integer',
         'PositiveSmallIntegerField': 'smallint',
@@ -74,7 +74,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     }
 
     data_type_check_constraints = {
-        'BooleanField': '%(qn_column)s IN (0,1)',
+        'BooleanField': '%(qn_column)s IN (0,1)', # for firebird 3 it changes in init_connection_state
         'NullBooleanField': '(%(qn_column)s IN (0,1)) OR (%(qn_column)s IS NULL)',
         'PositiveIntegerField': '%(qn_column)s >= 0',
         'PositiveSmallIntegerField': '%(qn_column)s >= 0',
@@ -181,7 +181,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     def init_connection_state(self):
         """Initializes the database connection settings."""
-        pass
+        if int(self.ops.firebird_version[3]) >= 3:
+            self.data_types['BooleanField'] = 'boolean'
+            self.data_types['NullBooleanField'] = 'boolean'
+            self.data_type_check_constraints['BooleanField'] = '%(qn_column)s IN (False,True)'
+            self.data_type_check_constraints['NullBooleanField'] = '(%(qn_column)s IN (False,True)) OR (%(qn_column)s IS NULL)'
 
     def create_cursor(self, name=None):
         """Creates a cursor. Assumes that a connection is established."""

--- a/firebird/base.py
+++ b/firebird/base.py
@@ -355,7 +355,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                 table = ''
                 with self.cursor() as cursor:
                     cursor.execute(select_relation)
-                    table = '"' + cursor.fetchone()[0].strip() + '"'
+                    res = cursor.fetchone()
+                    if not res:
+                        continue
+                    table = '"' + res[0].strip() + '"'
                 select_django_constraint_segment = """
                     select django$field_name as field_name from django$constraint_segment s 
                     where s.django$constraint_name = '%s'

--- a/firebird/base.py
+++ b/firebird/base.py
@@ -211,6 +211,17 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.enable_constraints()
 
     def disable_constraints(self):
+        """
+        Disables restrictions such as foreign keys, checks and unique.
+
+        .. important::
+
+           The server does not support explicit disabling of restrictions,
+           therefore, implementation is made using additional tables.
+
+        Note:
+           If there is an error when disable restrictions an exception is thrown.
+        """
         create_django_constraint = """
             create table django$constraint (
                 django$constraint_name varchar(31) not null constraint pk_djangocopyconstraint primary key,
@@ -331,6 +342,17 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             editor.execute(sql)
 
     def enable_constraints(self):
+        """
+        Enables restrictions that have been disabled by calling the method `disable_constraint_checking`.
+
+        .. important::
+
+           The server does not support explicit disabling of restrictions,
+           therefore, implementation is made using additional tables.
+
+        Note:
+           If there is an error when enable restrictions an exception is thrown.
+        """
         editor = self.schema_editor()
         select_django_constraint = """
         select django$constraint_name as constraint_name,
@@ -428,6 +450,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             print(e)
 
     def table_exists(self, table_name):
+        """
+        Checks whether a table with a specified name exists.
+
+        Args:
+            table_name (str): Table name for checking
+        """
         sql = """
             select null from rdb$relations where rdb$system_flag=0 and rdb$view_blr is null and rdb$relation_name='%s'
         """ % str(table_name).upper()
@@ -438,6 +466,20 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return True if value else False
 
     def get_drop_constraints(self, query):
+        """
+        Returns objects that should be dropped when restrictions are disabled.
+
+        Args:
+            query (str): SQL query to execute
+
+        .. important::
+
+           The server does not support explicit disabling of restrictions,
+           therefore, implementation is made using additional tables.
+
+        Note:
+           If there is an error when execute query an exception is thrown.
+        """
         value = []
         with self.cursor() as cursor:
             cursor.execute(query)

--- a/firebird/base.py
+++ b/firebird/base.py
@@ -201,7 +201,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         disabled and will need to be reenabled.
         """
         self.disable_constraints()
-        return False
+        return True
 
     def enable_constraint_checking(self):
         """

--- a/firebird/creation.py
+++ b/firebird/creation.py
@@ -59,10 +59,14 @@ class DatabaseCreation(BaseDatabaseCreation):
         if test_settings:
             if test_settings['NAME']:
                 params['database'] = settings_dict['NAME']
-            if test_settings['CHARSET']:
+            if 'CHARSET' in test_settings:
                 params['charset'] = test_settings['CHARSET']
-            if test_settings['PAGE_SIZE']:
+            else:
+                params['charset'] = "UTF8"
+            if 'PAGE_SIZE' in test_settings:
                 params['page_size'] = test_settings['PAGE_SIZE']
+            else:
+                params['page_size'] = 8192
         params.update(overrides)
         return params
 

--- a/firebird/creation.py
+++ b/firebird/creation.py
@@ -2,7 +2,6 @@ import sys
 import fdb as Database
 
 from django.db.backends.base.creation import BaseDatabaseCreation
-from django.utils.six.moves import input
 
 TEST_MODE = 0
 

--- a/firebird/creation.py
+++ b/firebird/creation.py
@@ -31,8 +31,7 @@ class DatabaseCreation(BaseDatabaseCreation):
 
     def _get_connection_params(self, **overrides):
         settings_dict = self.connection.settings_dict
-        conn_params = {'charset': 'UTF8'}
-        conn_params['database'] = settings_dict['NAME']
+        conn_params = {'charset': 'UTF8', 'database': settings_dict['NAME']}
         if settings_dict['HOST']:
             conn_params['host'] = settings_dict['HOST']
         if settings_dict['PORT']:
@@ -50,14 +49,22 @@ class DatabaseCreation(BaseDatabaseCreation):
     def _get_creation_params(self, **overrides):
         settings_dict = self.connection.settings_dict
         params = {'charset': 'UTF8'}
-        if settings_dict['USER']:
+        if 'HOST' in settings_dict:
+            params['host'] = settings_dict['HOST']
+        else:
+            params['host'] = 'localhost'
+        if 'PORT' in settings_dict:
+            params['port'] = settings_dict['PORT']
+        else:
+            params['port'] = '3050'
+        if 'USER' in settings_dict:
             params['user'] = settings_dict['USER']
-        if settings_dict['PASSWORD']:
+        if 'PASSWORD' in settings_dict:
             params['password'] = settings_dict['PASSWORD']
 
         test_settings = settings_dict.get('TEST')
         if test_settings:
-            if test_settings['NAME']:
+            if 'NAME' in test_settings:
                 params['database'] = settings_dict['NAME']
             if 'CHARSET' in test_settings:
                 params['charset'] = test_settings['CHARSET']
@@ -74,7 +81,7 @@ class DatabaseCreation(BaseDatabaseCreation):
         self._check_active_connection(verbosity)
         params = self._get_creation_params(database=test_database_name)
         connection = Database.create_database("""
-                        CREATE DATABASE '%(database)s'
+                        CREATE DATABASE '%(host)s/%(port)s:%(database)s'
                         USER '%(user)s'
                         PASSWORD '%(password)s'
                         PAGE_SIZE %(page_size)s

--- a/firebird/features.py
+++ b/firebird/features.py
@@ -11,7 +11,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_select_for_update_nowait = False
     has_select_for_update_skip_locked = False
     has_select_for_update_of = True
-    supports_forward_references = False
     supports_tablespaces = False
     supports_long_model_names = False
     supports_timezones = False
@@ -47,6 +46,13 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # Does the database driver supports same type temporal data subtraction
     # by returning the type used to store duration field?
     supports_temporal_subtraction = False
+
+    supports_microsecond_precision = False
+
+    can_introspect_null = True
+
+    # Commit every statements, that other transactions see changes.
+    autocommits_when_autocommit_is_off = True
 
     @cached_property
     def supports_transactions(self):

--- a/firebird/features.py
+++ b/firebird/features.py
@@ -13,8 +13,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_select_for_update_of = True
     supports_tablespaces = False
     supports_long_model_names = False
-    supports_timezones = False
-    has_zoneinfo_database = False
+    supports_timezones = True
+    has_zoneinfo_database = True
     uses_savepoints = True
     supports_paramstyle_pyformat = False
     connection_persists_old_columns = False

--- a/firebird/features.py
+++ b/firebird/features.py
@@ -1,3 +1,4 @@
+from django.db.models import NullBooleanField
 from django.utils.functional import cached_property
 from django.db.backends.base.features import BaseDatabaseFeatures
 
@@ -71,5 +72,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         introspection results; it should provide expectations, not run an introspection
         itself.
         """
-
+        if int(self.connection.ops.firebird_version[3]) >= 3:
+            if isinstance(field, NullBooleanField):
+                return 'BooleanField(blank=True, null=True)'
+            else:
+                return 'BooleanField'
         return 'SmallIntegerField'

--- a/firebird/features.py
+++ b/firebird/features.py
@@ -14,8 +14,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_select_for_update_of = True
     supports_tablespaces = False
     supports_long_model_names = False
-    supports_timezones = True
-    has_zoneinfo_database = True
+    supports_timezones = False
+    has_zoneinfo_database = False
     uses_savepoints = True
     supports_paramstyle_pyformat = False
     connection_persists_old_columns = False

--- a/firebird/introspection.py
+++ b/firebird/introspection.py
@@ -231,13 +231,17 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             else 'INDEX'
           end AS constraint_type,
 
-          s.RDB$FIELD_NAME AS field_name,
+          case
+            when s.RDB$FIELD_NAME is not null then s.RDB$FIELD_NAME
+            else ''
+          end AS field_name,
+          
           i2.RDB$RELATION_NAME AS references_table,
           s2.RDB$FIELD_NAME AS references_field,
           i.RDB$UNIQUE_FLAG,
           i.RDB$INDEX_TYPE
         FROM RDB$INDEX_SEGMENTS s
-        LEFT JOIN RDB$INDICES i ON i.RDB$INDEX_NAME = s.RDB$INDEX_NAME
+        FULL JOIN RDB$INDICES i ON i.RDB$INDEX_NAME = s.RDB$INDEX_NAME
         LEFT JOIN RDB$RELATION_CONSTRAINTS rc ON rc.RDB$INDEX_NAME = s.RDB$INDEX_NAME
         LEFT JOIN RDB$REF_CONSTRAINTS refc ON rc.RDB$CONSTRAINT_NAME = refc.RDB$CONSTRAINT_NAME
         LEFT JOIN RDB$RELATION_CONSTRAINTS rc2 ON rc2.RDB$CONSTRAINT_NAME = refc.RDB$CONST_NAME_UQ

--- a/firebird/introspection.py
+++ b/firebird/introspection.py
@@ -1,14 +1,19 @@
+import django
 import datetime
 import warnings
 
 from django.utils import six
 from django.utils.encoding import force_str
-from django.utils.deprecation import RemovedInDjango21Warning
 from django.db.models.indexes import Index
 from django.db.backends.base.introspection import (
     BaseDatabaseIntrospection, FieldInfo, TableInfo,
 )
 
+if (django.VERSION[0]==2 and django.VERSION[1] < 1) or django.VERSION[0] < 2:
+    # if django.version < 2.1
+    from django.utils.deprecation import RemovedInDjango21Warning
+else:
+    RemovedInDjango21Warning = None
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):
     # Maps type codes to Django Field types.
@@ -106,6 +111,10 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             items.append(FieldInfo(r[0], r[1], r[2], r[2] or 0, r[3], r[4], not (r[5] == 1), r[6]))
         return items
 
+    def get_sequences(self, cursor, table_name, table_fields=()):
+        pk_col = self.get_primary_key_column(cursor, table_name)
+        return [{'table': table_name, 'column': pk_col}]
+
     def get_key_columns(self, cursor, table_name):
         """
         Backends can override this to return a list of (column_name, referenced_table_name,
@@ -143,49 +152,50 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             relations[my_fieldname] = (other_field, other_table)
         return relations
 
-    def get_indexes(self, cursor, table_name):
-        """
-        Returns a dictionary of fieldname -> infodict for the given table,
-        where each infodict is in the format:
-            {'primary_key': boolean representing whether it's the primary key,
-             'unique': boolean representing whether it's a unique index/constraint}
-        """
+    if RemovedInDjango21Warning:
+        def get_indexes(self, cursor, table_name):
+            """
+            Returns a dictionary of fieldname -> infodict for the given table,
+            where each infodict is in the format:
+                {'primary_key': boolean representing whether it's the primary key,
+                 'unique': boolean representing whether it's a unique index/constraint}
+            """
 
-        warnings.warn(
-            "get_indexes() is deprecated in favor of get_constraints().",
-            RemovedInDjango21Warning, stacklevel=2
-        )
+            warnings.warn(
+                "get_indexes() is deprecated in favor of get_constraints().",
+                RemovedInDjango21Warning, stacklevel=2
+            )
 
-        # This query retrieves each field name and index type on the given table.
-        tbl_name = "'%s'" % table_name.upper()
-        cursor.execute("""
-        SELECT
-          LOWER(s.RDB$FIELD_NAME) AS field_name,
-
-          LOWER(case
-            when rc.RDB$CONSTRAINT_TYPE is not null then rc.RDB$CONSTRAINT_TYPE
-            else 'INDEX'
-          end) AS constraint_type
-
-        FROM RDB$INDEX_SEGMENTS s
-        LEFT JOIN RDB$INDICES i ON i.RDB$INDEX_NAME = s.RDB$INDEX_NAME
-        LEFT JOIN RDB$RELATION_CONSTRAINTS rc ON rc.RDB$INDEX_NAME = s.RDB$INDEX_NAME
-        WHERE i.RDB$RELATION_NAME = %s
-        AND i.RDB$SEGMENT_COUNT = 1
-        ORDER BY s.RDB$FIELD_POSITION
-        """ % (tbl_name,))
-        indexes = {}
-        for fn, ct in cursor.fetchall():
-            field_name = fn.strip()
-            constraint_type = ct.strip()
-            if field_name not in indexes:
-                indexes[field_name] = {'primary_key': False, 'unique': False}
-            # It's possible to have the unique and PK constraints in separate indexes.
-            if constraint_type == 'primary key':
-                indexes[field_name]['primary_key'] = True
-            if constraint_type == 'unique':
-                indexes[field_name]['unique'] = True
-        return indexes
+            # This query retrieves each field name and index type on the given table.
+            tbl_name = "'%s'" % table_name.upper()
+            cursor.execute("""
+            SELECT
+              LOWER(s.RDB$FIELD_NAME) AS field_name,
+    
+              LOWER(case
+                when rc.RDB$CONSTRAINT_TYPE is not null then rc.RDB$CONSTRAINT_TYPE
+                else 'INDEX'
+              end) AS constraint_type
+    
+            FROM RDB$INDEX_SEGMENTS s
+            LEFT JOIN RDB$INDICES i ON i.RDB$INDEX_NAME = s.RDB$INDEX_NAME
+            LEFT JOIN RDB$RELATION_CONSTRAINTS rc ON rc.RDB$INDEX_NAME = s.RDB$INDEX_NAME
+            WHERE i.RDB$RELATION_NAME = %s
+            AND i.RDB$SEGMENT_COUNT = 1
+            ORDER BY s.RDB$FIELD_POSITION
+            """ % (tbl_name,))
+            indexes = {}
+            for fn, ct in cursor.fetchall():
+                field_name = fn.strip()
+                constraint_type = ct.strip()
+                if field_name not in indexes:
+                    indexes[field_name] = {'primary_key': False, 'unique': False}
+                # It's possible to have the unique and PK constraints in separate indexes.
+                if constraint_type == 'primary key':
+                    indexes[field_name]['primary_key'] = True
+                if constraint_type == 'unique':
+                    indexes[field_name]['unique'] = True
+            return indexes
 
     def get_constraints(self, cursor, table_name):
         """

--- a/firebird/introspection.py
+++ b/firebird/introspection.py
@@ -25,6 +25,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         13: 'TimeField',
         14: 'CharField',
         16: 'BigIntegerField',
+        23: 'BooleanField',
         27: 'FloatField',
         35: 'DateTimeField',
         37: 'CharField',

--- a/firebird/introspection.py
+++ b/firebird/introspection.py
@@ -9,6 +9,8 @@ from django.db.backends.base.introspection import (
     BaseDatabaseIntrospection, FieldInfo, TableInfo,
 )
 
+# Because we want to maintain compatibility with the previous
+# version of django, we check current version of django
 if (django.VERSION[0]==2 and django.VERSION[1] < 1) or django.VERSION[0] < 2:
     # if django.version < 2.1
     from django.utils.deprecation import RemovedInDjango21Warning
@@ -25,7 +27,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         13: 'TimeField',
         14: 'CharField',
         16: 'BigIntegerField',
-        23: 'BooleanField',
+        23: 'BooleanField', # since firebird 3 boolean fields are supported
         27: 'FloatField',
         35: 'DateTimeField',
         37: 'CharField',
@@ -113,6 +115,18 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         return items
 
     def get_sequences(self, cursor, table_name, table_fields=()):
+        """
+        Return sequences for table.
+
+        Args:
+            cursor (Cursor): Database cursor
+            table_name (str): table
+            table_fields (list): table fields
+
+        .. important::
+
+           Firebird does not support introspected sequences for table.
+        """
         pk_col = self.get_primary_key_column(cursor, table_name)
         return [{'table': table_name, 'column': pk_col}]
 

--- a/firebird/operations.py
+++ b/firebird/operations.py
@@ -353,9 +353,13 @@ class DatabaseOperations(BaseDatabaseOperations):
             unit = 'second'
             value = str((decimal.Decimal(timedelta) * sign) / decimal.Decimal(1000000))
         elif isinstance(timedelta, six.string_types):
-            if timedelta.isdigit():
-                unit = 'second'
-                value = "(%s * %s) / 1000000" % (timedelta, sign,)
+            if timedelta.isdigit() or not "timestamp".casefold() in timedelta.casefold():
+                unit = 'millisecond'
+                value = "(%s * %s) / 1000" % (timedelta, sign,)
+            elif not "timestamp".casefold() in sql.casefold() and not timedelta.isdigit():
+                unit = 'millisecond'
+                value = "(%s * %s) / 1000" % (sql, sign,)
+                return 'DATEADD(%s %s TO %s)' % (value, unit, timedelta)
             else:
                 return super(DatabaseOperations, self).combine_duration_expression(connector, sub_expressions)
         else:

--- a/firebird/operations.py
+++ b/firebird/operations.py
@@ -28,8 +28,8 @@ class DatabaseOperations(BaseDatabaseOperations):
         'BigIntegerField': (Database.LONG_MIN, Database.LONG_MAX),
         'PositiveSmallIntegerField': (0, Database.SHRT_MAX),
         'PositiveIntegerField': (0, Database.INT_MAX),
-        'AutoField': (Database.INT_MIN, Database.INT_MAX),
-        'BigAutoField': (Database.LONG_MIN, Database.LONG_MAX),
+        'AutoField': (Database.INT_MIN, Database.INT_MAX), # since firebird 3 AutoField
+        'BigAutoField': (Database.LONG_MIN, Database.LONG_MAX), # and BigAutoField are supported
     }
 
     def __init__(self, connection, *args, **kwargs):
@@ -44,7 +44,16 @@ class DatabaseOperations(BaseDatabaseOperations):
         Access method for firebird_version property.
         firebird_version return the version number in an object list format
         Useful for ask for just a part of a version number.
-        (e.g. major version is firebird_version[0])
+
+        Indicies for parts:
+            PLATFORM = 0,
+            TYPE = 1,
+            FULL_VERSION = 2,
+            MAJOR = 3,
+            MINOR = 4,
+            VARIANT = 5,
+            BUILD = 6,
+            SERVER_NAME = 7.
         """
         server_version = self.connection.server_version
         pattern = re.compile(r"((\w{2})-(\w)(\d+)\.(\d+)\.(\d+)\.(\d+)(?:-\S+)?) (.+)")
@@ -271,6 +280,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             value = value.read()
         if value is not None:
             db_charset = None
+            # Trying to get character set from connection parameters to convert a string value
             if 'charset' in connection.get_connection_params():
                 if connection.get_connection_params()['charset'] in charset_map:
                     db_charset = charset_map[connection.get_connection_params()['charset']]

--- a/firebird/operations.py
+++ b/firebird/operations.py
@@ -1,4 +1,5 @@
 import decimal
+import re
 import uuid
 import datetime
 
@@ -46,7 +47,14 @@ class DatabaseOperations(BaseDatabaseOperations):
         (e.g. major version is firebird_version[0])
         """
         server_version = self.connection.server_version
-        return [int(val) for val in server_version.split()[-1].split('.')]
+        pattern = re.compile(r"((\w{2})-(\w)(\d+)\.(\d+)\.(\d+)\.(\d+)(?:-\S+)?) (.+)")
+        groups = pattern.match(server_version)
+        if not groups:
+            raise ValueError("Version string \"%s\" does not match expected format" % server_version)
+        result = []
+        for group in groups.groups():
+            result.append(group)
+        return result
 
     def autoinc_sql(self, table, column):
         sequence_name = get_autoinc_sequence_name(self, table)

--- a/firebird/schema.py
+++ b/firebird/schema.py
@@ -195,7 +195,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 params = {"column": self.quote_name(new_field.column), "type": new_type}
                 alter_sql = self.sql_alter_column_type % params
                 return ((alter_sql, [],), extra_sql,)
-        if new_type != self.connection.data_types['TextField'] or new_type != self.connection.data_types['BinaryField']:
+        if new_type != self.connection.data_types['TextField'] and new_type != self.connection.data_types['BinaryField']:
             return super(DatabaseSchemaEditor, self)._alter_column_type_sql(table, old_field, new_field, new_type)
         else:
             return ((alter_blob_actions), [],)

--- a/firebird/schema.py
+++ b/firebird/schema.py
@@ -829,7 +829,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     cur = tr.cursor()
                     cur.execute(str(sql), params)
                 except Exception as e:
-                    print(e)
                     raise e
         else:
             super(DatabaseSchemaEditor, self).execute(sql, params)

--- a/firebird/schema.py
+++ b/firebird/schema.py
@@ -321,6 +321,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         actions = []
         null_actions = []
         post_actions = []
+        fragment = None
         # Type change?
         if old_type != new_type:
             fragment, other_actions = self._alter_column_type_sql(

--- a/firebird/schema.py
+++ b/firebird/schema.py
@@ -557,7 +557,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     tr.commit()
             # TransactionContext automatically commit statement
             with TransactionContext(self.connection.connection.trans()) as tr:
-                cur = tr.cursor()
-                cur.execute(str(sql), params)
+                try:
+                    cur = tr.cursor()
+                    cur.execute(str(sql), params)
+                except Exception as e:
+                    print(e)
+                    raise e
         else:
             super(DatabaseSchemaEditor, self).execute(sql, params)

--- a/firebird/schema.py
+++ b/firebird/schema.py
@@ -647,7 +647,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         return FirebirdColumns(table, columns, self.quote_name, col_suffixes)
 
     def prepare_default(self, value):
-        if isinstance(value, bool):
+        if isinstance(value, bool) and int(self.connection.ops.firebird_version[3]) < 3:
             return "1" if value else "0"
         s = force_str(value)
         return self.quote_value(s)

--- a/firebird/schema.py
+++ b/firebird/schema.py
@@ -379,22 +379,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 # If this is the case, the individual schema backend should
                 # implement prepare_default
                 if self.connection.features.requires_literal_defaults:
-                    actions.append((
+                    self.execute(
                         self.sql_update_with_default % {
                             "table": self.quote_name(model._meta.db_table),
                             "column": self.quote_name(new_field.column),
                             "default": self.prepare_default(new_default),
                         },
                         [],
-                    ))
-                else:
-                    self.execute(
-                        self.sql_update_with_default % {
-                            "table": self.quote_name(model._meta.db_table),
-                            "column": self.quote_name(new_field.column),
-                            "default": "%s",
-                        },
-                        [new_default],
                     )
                 # Since we didn't run a NOT NULL change before we need to do it
                 # now

--- a/firebird/schema.py
+++ b/firebird/schema.py
@@ -754,7 +754,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         for field_names in model._meta.index_together:
             fields = [model._meta.get_field(field) for field in field_names]
             create_statement = self._create_index_sql(model, fields, suffix="_idx")
-            self.add_index(create_statement)
+            self.create_index(create_statement)
 
         for index in model._meta.indexes:
             self.add_index(self, model, index)
@@ -767,10 +767,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         output = []
         if self._field_should_be_indexed(model, field):
             create_statement = self._create_index_sql(model, [field])
-            self.add_index(create_statement)
+            self.create_index(create_statement)
         return output
 
-    def add_index(self, statement):
+    def create_index(self, statement):
         try:
             self.execute(statement, params=None)
         except Exception as e:

--- a/tests/test_main/dates/models.py
+++ b/tests/test_main/dates/models.py
@@ -17,7 +17,7 @@ class Article(models.Model):
 
 @python_2_unicode_compatible
 class Comment(models.Model):
-    article = models.ForeignKey(Article, related_name="comments")
+    article = models.ForeignKey(Article, related_name="comments", on_delete=models.CASCADE)
     text = models.TextField()
     pub_date = models.DateField()
     approval_date = models.DateField(null=True)

--- a/tests/test_main/dates/tests.py
+++ b/tests/test_main/dates/tests.py
@@ -105,7 +105,7 @@ class DatesTests(TestCase):
         six.assertRaisesRegex(
             self,
             AssertionError,
-            "'kind' must be one of 'year', 'month' or 'day'.",
+            "'kind' must be one of 'year', 'month', 'week', or 'day'.",
             Article.objects.dates,
             "pub_date",
             "bad_kind",

--- a/tests/test_main/datetimes/models.py
+++ b/tests/test_main/datetimes/models.py
@@ -17,7 +17,7 @@ class Article(models.Model):
 
 @python_2_unicode_compatible
 class Comment(models.Model):
-    article = models.ForeignKey(Article, related_name="comments")
+    article = models.ForeignKey(Article, related_name="comments", on_delete=models.CASCADE)
     text = models.TextField()
     pub_date = models.DateTimeField()
     approval_date = models.DateTimeField(null=True)

--- a/tests/test_main/inspectdb/models.py
+++ b/tests/test_main/inspectdb/models.py
@@ -2,24 +2,25 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from django.core import validators
 
 
 class People(models.Model):
     name = models.CharField(max_length=255)
-    parent = models.ForeignKey('self', models.CASCADE)
+    models.OneToOneField('self', models.CASCADE)
 
 
 class Message(models.Model):
-    from_field = models.ForeignKey(People, models.CASCADE, db_column='from_id')
+    from_field = models.OneToOneField(People, models.CASCADE, db_column='from_id')
 
 
 class PeopleData(models.Model):
-    people_pk = models.ForeignKey(People, models.CASCADE, primary_key=True)
+    people_pk = models.OneToOneField(People, models.CASCADE, primary_key=True)
     ssn = models.CharField(max_length=11)
 
 
 class PeopleMoreData(models.Model):
-    people_unique = models.ForeignKey(People, models.CASCADE, unique=True)
+    people_unique = models.OneToOneField(People, models.CASCADE, unique=True)
     license = models.CharField(max_length=255)
 
 
@@ -50,7 +51,7 @@ class ColumnTypes(models.Model):
     null_bool_field = models.NullBooleanField()
     char_field = models.CharField(max_length=10)
     null_char_field = models.CharField(max_length=10, blank=True, null=True)
-    comma_separated_int_field = models.CommaSeparatedIntegerField(max_length=99)
+    comma_separated_int_field = models.CharField(max_length=99, validators=[validators.validate_comma_separated_integer_list])
     date_field = models.DateField()
     date_time_field = models.DateTimeField()
     decimal_field = models.DecimalField(max_digits=6, decimal_places=1)

--- a/tests/test_main/inspectdb/tests.py
+++ b/tests/test_main/inspectdb/tests.py
@@ -85,7 +85,7 @@ class InspectDBTestCase(TestCase):
         null_bool_field = ColumnTypes._meta.get_field('null_bool_field')
         null_bool_field_type = connection.features.introspected_boolean_field_type(null_bool_field)
         if 'BooleanField' in null_bool_field_type:
-            assertFieldType('null_bool_field', "models.{}()".format(null_bool_field_type))
+            assertFieldType('null_bool_field', "models.{}".format(null_bool_field_type))
         else:
             if connection.features.can_introspect_null:
                 assertFieldType('null_bool_field', "models.{}(blank=True, null=True)".format(null_bool_field_type))

--- a/tests/test_main/introspection/models.py
+++ b/tests/test_main/introspection/models.py
@@ -15,7 +15,7 @@ class City(models.Model):
 
 @python_2_unicode_compatible
 class District(models.Model):
-    city = models.ForeignKey(City, models.CASCADE, primary_key=True)
+    city = models.OneToOneField(City, models.CASCADE, primary_key=True)
     name = models.CharField(max_length=50)
 
     def __str__(self):

--- a/tests/test_main/introspection/tests.py
+++ b/tests/test_main/introspection/tests.py
@@ -5,9 +5,17 @@ from unittest import skipUnless
 from django.db import connection
 from django.db.models import Index
 from django.db.utils import DatabaseError
-from django.test import TransactionTestCase, mock, skipUnlessDBFeature
+from django.test import TransactionTestCase, skipUnlessDBFeature
 from django.test.utils import ignore_warnings
-from django.utils.deprecation import RemovedInDjango21Warning
+
+import django
+import mock
+
+if (django.VERSION[0]==2 and django.VERSION[1] < 1) or django.VERSION[0] < 2:
+    # if django.version < 2.1
+    from django.utils.deprecation import RemovedInDjango21Warning
+else:
+    RemovedInDjango21Warning = None
 
 from .models import Article, ArticleReporter, City, District, Reporter
 
@@ -173,19 +181,21 @@ class IntrospectionTests(TransactionTestCase):
 
     @ignore_warnings(category=RemovedInDjango21Warning)
     def test_get_indexes(self):
-        with connection.cursor() as cursor:
-            indexes = connection.introspection.get_indexes(cursor, Article._meta.db_table)
-        self.assertEqual(indexes['reporter_id'], {'unique': False, 'primary_key': False})
+        if RemovedInDjango21Warning:
+            with connection.cursor() as cursor:
+                indexes = connection.introspection.get_indexes(cursor, Article._meta.db_table)
+            self.assertEqual(indexes['reporter_id'], {'unique': False, 'primary_key': False})
 
     @ignore_warnings(category=RemovedInDjango21Warning)
     def test_get_indexes_multicol(self):
-        """
-        Multicolumn indexes are not included in the introspection results.
-        """
-        with connection.cursor() as cursor:
-            indexes = connection.introspection.get_indexes(cursor, Reporter._meta.db_table)
-        self.assertNotIn('first_name', indexes)
-        self.assertIn('id', indexes)
+        if RemovedInDjango21Warning:
+            """
+            Multicolumn indexes are not included in the introspection results.
+            """
+            with connection.cursor() as cursor:
+                indexes = connection.introspection.get_indexes(cursor, Reporter._meta.db_table)
+            self.assertNotIn('first_name', indexes)
+            self.assertIn('id', indexes)
 
     def test_get_constraints_index_types(self):
         with connection.cursor() as cursor:

--- a/tests/test_main/lookup/tests.py
+++ b/tests/test_main/lookup/tests.py
@@ -491,7 +491,7 @@ class LookupTests(TestCase):
         except FieldError as ex:
             self.assertEqual(
                 str(ex), "Unsupported lookup 'starts' for CharField "
-                "or join on the field not permitted.")
+                "or join on the field not permitted, perhaps you meant startswith or istartswith?")
 
     def test_relation_nested_lookup_error(self):
         # An invalid nested lookup on a related field raises a useful error.
@@ -683,13 +683,13 @@ class LookupTests(TestCase):
         season_2011.games.create(home="Houston Astros", away="St. Louis Cardinals")
         season_2011.games.create(home="Houston Astros", away="Milwaukee Brewers")
         hunter_pence = Player.objects.create(name="Hunter Pence")
-        hunter_pence.games = Game.objects.filter(season__year__in=[2009, 2010])
+        hunter_pence.games.set(Game.objects.filter(season__year__in=[2009, 2010]))
         pudge = Player.objects.create(name="Ivan Rodriquez")
-        pudge.games = Game.objects.filter(season__year=2009)
+        pudge.games.set(Game.objects.filter(season__year=2009))
         pedro_feliz = Player.objects.create(name="Pedro Feliz")
-        pedro_feliz.games = Game.objects.filter(season__year__in=[2011])
+        pedro_feliz.games.set(Game.objects.filter(season__year__in=[2011]))
         johnson = Player.objects.create(name="Johnson")
-        johnson.games = Game.objects.filter(season__year__in=[2011])
+        johnson.games.set(Game.objects.filter(season__year__in=[2011]))
 
         # Games in 2010
         self.assertEqual(Game.objects.filter(season__year=2010).count(), 3)

--- a/tests/test_main/many_to_one/tests.py
+++ b/tests/test_main/many_to_one/tests.py
@@ -1,4 +1,8 @@
 import datetime
+from unittest import skipUnless
+
+import django
+
 from copy import deepcopy
 
 from django.core.exceptions import FieldError, MultipleObjectsReturned
@@ -6,8 +10,14 @@ from django.db import models, transaction
 from django.db.utils import IntegrityError
 from django.test import TestCase, ignore_warnings
 from django.utils import six
-from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.translation import ugettext_lazy
+
+if django.VERSION[0] < 2:
+    # if django.version < 2.0
+    from django.utils.deprecation import RemovedInDjango20Warning
+else:
+    RemovedInDjango21Warning = None
+
 
 from .models import (
     Article, Category, Child, City, District, First, Parent, Record, Relation,
@@ -580,6 +590,7 @@ class ManyToOneTests(TestCase):
         with self.assertNumQueries(1):
             self.assertEqual(th.child_set.count(), 0)
 
+    @skipUnless(RemovedInDjango20Warning == None, "RemovedInDjango20Warning is not defined")
     @ignore_warnings(category=RemovedInDjango20Warning)  # for use_for_related_fields deprecation
     def test_related_object(self):
         public_school = School.objects.create(is_public=True)

--- a/tests/test_main/model_fields/models.py
+++ b/tests/test_main/model_fields/models.py
@@ -12,6 +12,7 @@ from django.db.models.fields.files import ImageField, ImageFieldFile
 from django.db.models.fields.related import (
     ForeignKey, ForeignObject, ManyToManyField, OneToOneField,
 )
+from django.core import validators
 from django.utils import six
 
 try:
@@ -31,7 +32,7 @@ def get_foo():
 
 class Bar(models.Model):
     b = models.CharField(max_length=10)
-    a = models.ForeignKey(Foo, models.CASCADE, default=get_foo, related_name=b'bars')
+    a = models.ForeignKey(Foo, models.CASCADE, default=get_foo, related_name='bars')
 
 
 class Whiz(models.Model):
@@ -164,7 +165,7 @@ class VerboseNameField(models.Model):
     field1 = models.BigIntegerField("verbose field1")
     field2 = models.BooleanField("verbose field2", default=False)
     field3 = models.CharField("verbose field3", max_length=10)
-    field4 = models.CommaSeparatedIntegerField("verbose field4", max_length=99)
+    field4 = models.CharField("verbose field4", max_length=99, validators=[validators.validate_comma_separated_integer_list])
     field5 = models.DateField("verbose field5")
     field6 = models.DateTimeField("verbose field6")
     field7 = models.DecimalField("verbose field7", max_digits=6, decimal_places=1)
@@ -323,7 +324,7 @@ class AllFieldsModel(models.Model):
     binary = models.BinaryField()
     boolean = models.BooleanField(default=False)
     char = models.CharField(max_length=10)
-    csv = models.CommaSeparatedIntegerField(max_length=10)
+    csv = models.CharField(max_length=10, validators=[validators.validate_comma_separated_integer_list])
     date = models.DateField()
     datetime = models.DateTimeField()
     decimal = models.DecimalField(decimal_places=2, max_digits=2)

--- a/tests/test_main/model_fields/test_decimalfield.py
+++ b/tests/test_main/model_fields/test_decimalfield.py
@@ -1,9 +1,11 @@
 from decimal import Decimal
+from unittest import skipUnless
 
 from django.core import validators
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.test import TestCase
+from pytest import skip
 
 from .models import BigD, Foo
 
@@ -21,6 +23,7 @@ class DecimalFieldTests(TestCase):
         f = models.DecimalField(default=Decimal('0.00'))
         self.assertEqual(f.get_default(), Decimal('0.00'))
 
+    @skipUnless("DecimalField hasn't _format() method")
     def test_format(self):
         f = models.DecimalField(max_digits=5, decimal_places=1)
         self.assertEqual(f._format(f.to_python(2)), '2.0')

--- a/tests/test_main/schema/tests.py
+++ b/tests/test_main/schema/tests.py
@@ -484,6 +484,27 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.remove_index(LocalBook, index)
 
+    def test_unique_together_big_varchar(self):
+        class LocalBook(Model):
+            author = IntegerField()
+            title = CharField(max_length=4096)
+            pub_date = DateTimeField()
+
+            class Meta:
+                app_label = 'schema'
+                apps = new_apps
+        # Create the table
+        with connection.schema_editor() as editor:
+            editor.create_model(LocalBook)
+        # Ensure the fields are unique to begin with
+        self.assertEqual(LocalBook._meta.unique_together, ())
+        # Add the unique_together constraint
+        with connection.schema_editor() as editor:
+            editor.alter_unique_together(LocalBook, [], [['author', 'title']])
+        # Alter it back
+        with connection.schema_editor() as editor:
+            editor.alter_unique_together(LocalBook, [['author', 'title']], [])
+
     def test_add_field_temp_default(self):
         """
         Tests adding fields to models with a temporary default

--- a/tests/test_main/schema/tests.py
+++ b/tests/test_main/schema/tests.py
@@ -485,12 +485,36 @@ class SchemaTests(TransactionTestCase):
             editor.remove_index(LocalBook, index)
 
     def test_unique_together_big_varchar(self):
+        class LocalBookUnique(Model):
+            author = IntegerField()
+            title = CharField(max_length=4096)
+            pub_date = DateTimeField()
+
+            class Meta:
+                app_label = 'schema'
+                apps = new_apps
+        # Create the table
+        with connection.schema_editor() as editor:
+            editor.create_model(LocalBookUnique)
+        # Ensure the fields are unique to begin with
+        self.assertEqual(LocalBookUnique._meta.unique_together, ())
+        # Add the unique_together constraint
+        with connection.schema_editor() as editor:
+            editor.alter_unique_together(LocalBookUnique, [], [['author', 'title']])
+        # Alter it back
+        with connection.schema_editor() as editor:
+            editor.alter_unique_together(LocalBookUnique, [['author', 'title']], [])
+
+    def test_unique_together_alter_big_varchar(self):
         class LocalBook(Model):
             author = IntegerField()
             title = CharField(max_length=4096)
             pub_date = DateTimeField()
 
             class Meta:
+                # unique_together = [
+                #     ('author', 'title'),
+                # ]
                 app_label = 'schema'
                 apps = new_apps
         # Create the table
@@ -501,9 +525,41 @@ class SchemaTests(TransactionTestCase):
         # Add the unique_together constraint
         with connection.schema_editor() as editor:
             editor.alter_unique_together(LocalBook, [], [['author', 'title']])
+        # Alter field
+        old_field = LocalBook._meta.get_field("title")
+        new_field = CharField(max_length=4097)
+        new_field.set_attributes_from_name("title")
+        with connection.schema_editor() as editor:
+            editor.alter_field(LocalBook, old_field, new_field, strict=True)
         # Alter it back
         with connection.schema_editor() as editor:
             editor.alter_unique_together(LocalBook, [['author', 'title']], [])
+
+    def test_alter_numeric_with_big_varchar_unique(self):
+        """
+        Changing a field type shouldn't affect the not null status.
+        """
+        class UniqueTestLocal(Model):
+            year = IntegerField()
+            slug = CharField(max_length=95)
+
+            class Meta:
+                app_label = 'schema'
+                apps = new_apps
+                unique_together = ["year", "slug"]
+        self.local_models = [UniqueTestLocal]
+
+        with connection.schema_editor() as editor:
+            editor.create_model(UniqueTestLocal)
+        with self.assertRaises(IntegrityError):
+            UniqueTestLocal.objects.create(year=None, slug='aaa')
+        old_field = UniqueTestLocal._meta.get_field("slug")
+        new_field = CharField(max_length=4095)
+        new_field.set_attributes_from_name("slug")
+        with connection.schema_editor() as editor:
+            editor.alter_field(UniqueTestLocal, old_field, new_field, strict=True)
+        with self.assertRaises(IntegrityError):
+            UniqueTestLocal.objects.create(year=None, slug='bbb')
 
     def test_add_field_temp_default(self):
         """
@@ -1841,13 +1897,13 @@ class SchemaTests(TransactionTestCase):
         self.assertNotIn('title', self.get_indexes(Author._meta.db_table))
         index_name = 'author_name_idx'
         # Add the index
-        index = Index(fields=['name', '-weight'], name=index_name)
+        index = Index(fields=['name', 'weight'], name=index_name)
         with connection.schema_editor() as editor:
             editor.add_index(Author, index)
         if connection.features.supports_index_column_ordering:
             if connection.features.uppercases_column_names:
                 index_name = index_name.upper()
-            self.assertIndexOrder(Author._meta.db_table, index_name, ['ASC', 'DESC'])
+            self.assertIndexOrder(Author._meta.db_table, index_name, ['ASC', 'ASC'])
         # Drop the index
         with connection.schema_editor() as editor:
             editor.remove_index(Author, index)

--- a/tests/test_main/schema/tests.py
+++ b/tests/test_main/schema/tests.py
@@ -1,5 +1,6 @@
 import datetime
 import itertools
+import mock
 import unittest
 from copy import copy
 
@@ -19,7 +20,7 @@ from django.db.models.fields.related import (
 from django.db.models.indexes import Index
 from django.db.transaction import TransactionManagementError, atomic
 from django.test import (
-    TransactionTestCase, mock, skipIfDBFeature, skipUnlessDBFeature,
+    TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature,
 )
 from django.test.utils import CaptureQueriesContext, isolate_apps, patch_logger
 from django.utils import timezone

--- a/tests/test_main/schema/tests.py
+++ b/tests/test_main/schema/tests.py
@@ -2350,6 +2350,7 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(Author, new_field, old_field, strict=True)
         self.assertEqual(self.get_constraints_for_column(Author, 'weight'), [])
 
+    @unittest.skipIf(connection.vendor == 'firebird', "FirebirdSQL specific")
     def test_alter_pk_with_self_referential_field(self):
         """
         Changing the primary key field name of a model with a self-referential

--- a/tests/test_main/test_base/models.py
+++ b/tests/test_main/test_base/models.py
@@ -20,7 +20,7 @@ class Foo(models.Model):
 
 class Bar(models.Model):
     b = models.CharField(max_length=10)
-    a = models.ForeignKey(Foo, related_name=b'bars')
+    a = models.ForeignKey(Foo, related_name='bars', on_delete=models.CASCADE)
 
 
 @python_2_unicode_compatible

--- a/tests/test_main/test_base/tests.py
+++ b/tests/test_main/test_base/tests.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.db import connection, DatabaseError
-from django.db.models import F, DateField, DateTimeField, IntegerField, TimeField
+from django.db.models import F, DateField, DateTimeField, IntegerField, TimeField, CASCADE
 from django.db.models.fields.related import ForeignKey
 from django.db.models.functions import (
     Extract, ExtractDay, ExtractHour, ExtractMinute, ExtractMonth,
@@ -13,6 +13,7 @@ from django.db.models.functions import (
     TruncYear,
 )
 from django.test import TestCase, TransactionTestCase, override_settings
+from django.utils import timezone
 
 
 from .models import BigS, FieldsTest, Foo, Bar, DTModel
@@ -97,27 +98,27 @@ class DatabaseOperationsTest(TestCase):
         self.assertEqual(sql, value)
 
     def test_datetime_trunc_sql(self):
-        sql, params = self.ops.datetime_trunc_sql('year', 'DATE_FIELD', None)
+        sql = self.ops.datetime_trunc_sql('year', 'DATE_FIELD', None)
         value = "CAST(EXTRACT(year FROM DATE_FIELD)||'-01-01 00:00:00' AS TIMESTAMP)"
         self.assertEqual(sql, value)
 
-        sql, params = self.ops.datetime_trunc_sql('month', 'DATE_FIELD', None)
+        sql = self.ops.datetime_trunc_sql('month', 'DATE_FIELD', None)
         value = "CAST(EXTRACT(year FROM DATE_FIELD)||'-'||EXTRACT(month FROM DATE_FIELD)||'-01 00:00:00' AS TIMESTAMP)"
         self.assertEqual(sql, value)
 
-        sql, params = self.ops.datetime_trunc_sql('day', 'DATE_FIELD', None)
+        sql = self.ops.datetime_trunc_sql('day', 'DATE_FIELD', None)
         value = "CAST(EXTRACT(year FROM DATE_FIELD)||'-'||EXTRACT(month FROM DATE_FIELD)||'-'||EXTRACT(day FROM DATE_FIELD)||' 00:00:00' AS TIMESTAMP)"
         self.assertEqual(sql, value)
 
-        sql, params = self.ops.datetime_trunc_sql('hour', 'DATE_FIELD', None)
+        sql = self.ops.datetime_trunc_sql('hour', 'DATE_FIELD', None)
         value = "CAST(EXTRACT(year FROM DATE_FIELD)||'-'||EXTRACT(month FROM DATE_FIELD)||'-'||EXTRACT(day FROM DATE_FIELD)||' '||EXTRACT(hour FROM DATE_FIELD)||':00:00' AS TIMESTAMP)"
         self.assertEqual(sql, value)
 
-        sql, params = self.ops.datetime_trunc_sql('minute', 'DATE_FIELD', None)
+        sql = self.ops.datetime_trunc_sql('minute', 'DATE_FIELD', None)
         value = "CAST(EXTRACT(year FROM DATE_FIELD)||'-'||EXTRACT(month FROM DATE_FIELD)||'-'||EXTRACT(day FROM DATE_FIELD)||' '||EXTRACT(hour FROM DATE_FIELD)||':'||EXTRACT(minute FROM DATE_FIELD)||':00' AS TIMESTAMP)"
         self.assertEqual(sql, value)
 
-        sql, params = self.ops.datetime_trunc_sql('second', 'DATE_FIELD', None)
+        sql = self.ops.datetime_trunc_sql('second', 'DATE_FIELD', None)
         value = "CAST(EXTRACT(year FROM DATE_FIELD)||'-'||EXTRACT(month FROM DATE_FIELD)||'-'||EXTRACT(day FROM DATE_FIELD)||' '||EXTRACT(hour FROM DATE_FIELD)||':'||EXTRACT(minute FROM DATE_FIELD)||':'||TRUNC(EXTRACT(second FROM DATE_FIELD)) AS TIMESTAMP)"
         self.assertEqual(sql, value)
 
@@ -144,7 +145,7 @@ class DatabaseSchemaTests(TransactionTestCase):
         self.assertEqual(index_sql, [])
 
     def test_fk_index_creation(self):
-        new_field = ForeignKey(Foo)
+        new_field = ForeignKey(Foo, on_delete=CASCADE)
         new_field.set_attributes_from_name(None)
         with connection.schema_editor() as editor:
             editor.add_field(


### PR DESCRIPTION
Improvements:

1. Separate transaction for DDL statement. Each transaction is committed to make the changes visible to other statements. It's managed by 'autocommits_when_autocommit_is_off' feature. Set it to 'False' to disable separate transactions.
2. Limit on creating big VARCHAR fields. If size is exceeded, it's changed to allowed. For big VARCHAR field an index with hash expression is created.
3. Index with hash expression for big unique constraints. It's not possible to create a unique on big VARCHAR. Instead of it an unique index is created using hash expression.
4. Implemented disabling and enabling constraint checking. To disable and enable constraint checking are created additional tables. 'django$constraint' and 'django$constraint_segment' store foreigns keys, unique fields and checks until constraint check is enabled.
5. Altering field from blob type from/to another type. Firebird does not support direct type change to/from BLOB type. It was split into 4 steps:
    5.1. Make a temp blob column.
    5.2. Write the old column data to the new blob column.
    5.3. Drop the old column.
    5.4. Rename the temp column to old name.
6. Support for AutoField and BigAutoField integer fields.
7. Support for BOOLEAN type.

Fixed:

1. Altering column from NULL to NOT NULL and vice versa.
2. Default parameter passing for column. Default value is added to query instead of passing as parameter.
3. Processing dates and datetimes expressions. No need to return an empty parameter list, but only sql text.
4. Using of DISTINCT keyword for building sql queries.
5. Checking of connection parameters.
6. Updating null fields with default values before alter. A query to set default value is executed immediately to avoid errors.
7. Using host and port for test database creation.
8. Checking if a sequence exists before deleting.
9. Parsing server version. The server version is parsed in the following order: full version, platform, type, major, minor, variant, build, server name.
10. Combining of duration expression. If the expression contains a string type containing a integer or bigint value, using DATEADD function.
11. Minor fixes for sql queries to work with Firebird 3.
12. Fixes related to the django version. Updating imports, etc.

Tested with Django 2.2.10/2.2.11 and Firebird 3.0.5.