### PR TITLE
Decimal is not float

### DIFF
--- a/firebird/operations.py
+++ b/firebird/operations.py
@@ -306,7 +306,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         val = utils.format_number(value, field.max_digits, field.decimal_places)
         
         if val is not None:
-            value = decimal.Decimal.from_float(float(val))
+            value = decimal.Decimal(val)
             
         return value
 


### PR DESCRIPTION
Decimal type is fixed point python type. Float is floating point. Conversion from float to Decimal causes rounding errors and wrong data are displayed.