### PR TITLE
feat: add support for Django 3.2+

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,5 +11,6 @@ Contributors
 - Thomas Steinmaurer (tsteinmaurer)
 - Vasiliy Yashkov <vasiliy.yashkov@red-soft.ru>
 - Artyom Smirnov <artyom.smirnov@red-soft.ru>
+- Vinit Kumar <mail@vinitkumar.me>
 
 And all people who use, test and report issues

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ the branch list of this repository.
 Requirements
 ------------
   * Python 3.x
-  * Django 2.2.x
+  * Django 3.2.x
   * fdb (http://pypi.python.org/pypi/fdb/)
 
 Installation

--- a/firebird/base.py
+++ b/firebird/base.py
@@ -123,7 +123,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     ops_class = DatabaseOperations
 
     def __init__(self, *args, **kwargs):
-        super(DatabaseWrapper, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self._server_version = None
         self._db_charset = None
@@ -331,11 +331,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         constraints = self.get_drop_constraints(select_drop_constraints)
         for hm in constraints:
             sql = """
-                alter table "%(table)s" drop constraint "%(constraint)s"
-            """ % {
-                'table': hm['TABLE_NAME'],
-                'constraint': hm['CONSTR_NAME']
-            }
+                alter table "{table}" drop constraint "{constraint}"
+            """.format(
+                table=hm['TABLE_NAME'],
+                constraint=hm['CONSTR_NAME']
+            )
             editor.execute(sql)
 
     def enable_constraints(self):
@@ -541,7 +541,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return self._server_version
 
 
-class FirebirdCursorWrapper(object):
+class FirebirdCursorWrapper:
     """
     Django uses "format" style placeholders, but firebird uses "qmark" style.
     This fixes it -- but note that if you want to use a literal "%s" in a query,

--- a/firebird/client.py
+++ b/firebird/client.py
@@ -13,7 +13,7 @@ class DatabaseClient(BaseDatabaseClient):
             self.executable_name = 'isql'
         else:
             self.executable_name = 'isql-fb'
-        super(DatabaseClient, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _get_args(self):
         args = [self.executable_name]

--- a/firebird/compiler.py
+++ b/firebird/compiler.py
@@ -21,7 +21,7 @@ class SQLCompiler(compiler.SQLCompiler):
         return row[:index_start] + tuple(values)
 
     def as_sql(self, with_limits=True, with_col_aliases=False):
-        sql, params = super(SQLCompiler, self).as_sql(with_limits=False, with_col_aliases=with_col_aliases)
+        sql, params = super().as_sql(with_limits=False, with_col_aliases=with_col_aliases)
 
         if with_limits:
             limits = []
@@ -33,7 +33,7 @@ class SQLCompiler(compiler.SQLCompiler):
                     if val:
                         limits.append('FIRST %d' % val)
                 limits.append('SKIP %d' % self.query.low_mark)
-            sql = 'SELECT %s %s' % (' '.join(limits), sql[6:].strip())
+            sql = 'SELECT {} {}'.format(' '.join(limits), sql[6:].strip())
         return sql, params
 
 

--- a/firebird/creation.py
+++ b/firebird/creation.py
@@ -14,13 +14,13 @@ class DatabaseCreation(BaseDatabaseCreation):
 
     def sql_for_pending_references(self, model, style, pending_references):
         if TEST_MODE < 2:
-            final_output = super(DatabaseCreation, self).sql_for_pending_references(model, style, pending_references)
+            final_output = super().sql_for_pending_references(model, style, pending_references)
             return ['%s ON DELETE CASCADE;' % s[:-1] for s in final_output]
         return []
 
     def sql_remove_table_constraints(self, model, references_to_delete, style):
         if TEST_MODE < 2:
-            return super(DatabaseCreation, self).sql_remove_table_constraints(model, references_to_delete, style)
+            return super().sql_remove_table_constraints(model, references_to_delete, style)
         return []
 
     def _check_active_connection(self, verbosity):

--- a/firebird/features.py
+++ b/firebird/features.py
@@ -1,4 +1,4 @@
-from django.db.models import NullBooleanField
+from django.db.models import BooleanField
 from django.utils.functional import cached_property
 from django.db.backends.base.features import BaseDatabaseFeatures
 

--- a/firebird/introspection.py
+++ b/firebird/introspection.py
@@ -96,10 +96,10 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             from
               rdb$relation_fields rf join rdb$fields f on (rf.rdb$field_source = f.rdb$field_name)
             where
-              upper(rf.rdb$relation_name) = %s
+              upper(rf.rdb$relation_name) = {}
             order by
               rf.rdb$field_position
-            """ % (tbl_name,))
+            """.format(tbl_name))
         items = []
         for r in cursor.fetchall():
             # name type_code display_size internal_size precision scale null_ok + default
@@ -142,7 +142,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             left join rdb$indices i2 on i2.rdb$index_name = rc2.rdb$index_name
             left join rdb$index_segments s2 on i2.rdb$index_name = s2.rdb$index_name
             WHERE RC.RDB$CONSTRAINT_TYPE = 'FOREIGN KEY'
-            and upper(i.rdb$relation_name) = %s """ % (tbl_name,))
+            and upper(i.rdb$relation_name) = {} """.format(tbl_name))
 
         for r in cursor.fetchall():
             key_columns.append((r[0].strip(), r[1].strip(), r[2].strip()))
@@ -210,9 +210,9 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         LEFT JOIN RDB$RELATION_CONSTRAINTS rc2 ON rc2.RDB$CONSTRAINT_NAME = refc.RDB$CONST_NAME_UQ
         LEFT JOIN RDB$INDICES i2 ON i2.RDB$INDEX_NAME = rc2.RDB$INDEX_NAME
         LEFT JOIN RDB$INDEX_SEGMENTS s2 ON i2.RDB$INDEX_NAME = s2.RDB$INDEX_NAME
-        WHERE i.RDB$RELATION_NAME = %s
+        WHERE i.RDB$RELATION_NAME = {}
         ORDER BY s.RDB$FIELD_POSITION
-        """ % (tbl_name,))
+        """.format(tbl_name))
         for constraint_name, constraint_type, column, other_table, other_column, unique, order, expression in cursor.fetchall():
             primary_key = False
             foreign_key = None
@@ -269,10 +269,10 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             from rdb$index_segments s
             left join rdb$indices i on i.rdb$index_name = s.rdb$index_name
             left join rdb$relation_constraints rc on rc.rdb$index_name = s.rdb$index_name
-            where i.rdb$relation_name = %s
-            and s.rdb$field_name = %s
+            where i.rdb$relation_name = {}
+            and s.rdb$field_name = {}
             and rc.rdb$constraint_type is null
-            order by s.rdb$field_position """ % (table, field,))
+            order by s.rdb$field_position """.format(table, field))
 
         return [index_name[0].strip() for index_name in cursor.fetchall()]
 
@@ -280,4 +280,4 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         """Return a dictionary of {field_name: field_index} for the given table.
            Indexes are 0-based.
         """
-        return dict([(d[0], i) for i, d in enumerate(self.get_table_description(cursor, table_name))])
+        return {d[0]: i for i, d in enumerate(self.get_table_description(cursor, table_name))}

--- a/firebird/operations.py
+++ b/firebird/operations.py
@@ -11,7 +11,7 @@ from django.db.backends import utils
 from django.db.utils import DatabaseError
 from django.utils.functional import cached_property
 from django.utils import timezone
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 
 from .base import Database
 
@@ -257,9 +257,9 @@ class DatabaseOperations(BaseDatabaseOperations):
                 if connection.get_connection_params()['charset'] in charset_map:
                     db_charset = charset_map[connection.get_connection_params()['charset']]
             if db_charset:
-                value = force_text(value, encoding=db_charset, errors='replace')
+                value = force_str(value, encoding=db_charset, errors='replace')
             else:
-                value = force_text(value)
+                value = force_str(value)
         return value
 
     def convert_binaryfield_value(self, value, expression, connection, context):

--- a/firebird/schema.py
+++ b/firebird/schema.py
@@ -68,12 +68,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         sql = """
             SELECT a.RDB$DEFAULT_VALUE
             FROM RDB$RELATION_FIELDS a
-            WHERE UPPER(a.RDB$FIELD_NAME) = UPPER('%(column)s')
-            AND UPPER(a.RDB$RELATION_NAME) = UPPER('%(table_name)s')
-        """ % {
-            'column': params['column'],
-            'table_name': params['table_name']
-        }
+            WHERE UPPER(a.RDB$FIELD_NAME) = UPPER('{column}')
+            AND UPPER(a.RDB$RELATION_NAME) = UPPER('{table_name}')
+        """.format(
+            column=params['column'],
+            table_name=params['table_name']
+        )
 
         res = None
         with self.connection.cursor() as cursor:
@@ -222,7 +222,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             self.connection.commit()
 
     def _field_should_be_indexed(self, model, field):
-        create_index = super(DatabaseSchemaEditor, self)._field_should_be_indexed(model, field)
+        create_index = super()._field_should_be_indexed(model, field)
 
         # No need to create an index for ForeignKey fields except if
         # db_constraint=False because the index from that constraint won't be
@@ -251,7 +251,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             sql = self._delete_constraint_sql(self.sql_delete_index, model, index_name)
             self.execute(sql)
 
-        super(DatabaseSchemaEditor, self).remove_field(model, field)
+        super().remove_field(model, field)
 
     def _alter_column_type_sql(self, table, old_field, new_field, new_type):
         # The Firebird does not support direct type change to BLOB,
@@ -311,7 +311,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 return ((alter_sql, [],), extra_sql,)
         if new_type != self.connection.data_types['TextField'] and new_type != self.connection.data_types[
             'BinaryField']:
-            return super(DatabaseSchemaEditor, self)._alter_column_type_sql(table, old_field, new_field, new_type)
+            return super()._alter_column_type_sql(table, old_field, new_field, new_type)
         else:
             return ((alter_blob_actions), [],)
 
@@ -346,7 +346,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         if old_field.remote_field and old_field.db_constraint:
             fk_names = self._constraint_names(model, [old_field.column], foreign_key=True)
             if strict and len(fk_names) != 1:
-                raise ValueError("Found wrong number (%s) of foreign key constraints for %s.%s" % (
+                raise ValueError("Found wrong number ({}) of foreign key constraints for {}.{}".format(
                     len(fk_names),
                     model._meta.db_table,
                     old_field.column,
@@ -359,7 +359,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # Find the unique constraint for this field
             constraint_names = self._constraint_names(model, [old_field.column], unique=True)
             if strict and len(constraint_names) != 1:
-                raise ValueError("Found wrong number (%s) of unique constraints for %s.%s" % (
+                raise ValueError("Found wrong number ({}) of unique constraints for {}.{}".format(
                     len(constraint_names),
                     model._meta.db_table,
                     old_field.column,
@@ -411,7 +411,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             if old_db_params['check'] != new_db_params['check'] and old_db_params['check']:
                 constraint_names = self._constraint_names(model, [old_field.column], check=True)
                 if strict and len(constraint_names) != 1:
-                    raise ValueError("Found wrong number (%s) of check constraints for %s.%s" % (
+                    raise ValueError("Found wrong number ({}) of check constraints for {}.{}".format(
                         len(constraint_names),
                         model._meta.db_table,
                         old_field.column,
@@ -577,7 +577,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # First, drop the old PK
             constraint_names = self._constraint_names(model, primary_key=True)
             if strict and len(constraint_names) != 1:
-                raise ValueError("Found wrong number (%s) of PK constraints for %s" % (
+                raise ValueError("Found wrong number ({}) of PK constraints for {}".format(
                     len(constraint_names),
                     model._meta.db_table,
                 ))
@@ -735,7 +735,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 elif self.connection.features.supports_foreign_keys:
                     self.deferred_sql.append(self._create_fk_sql(model, field, "_fk_%(to_table)s_%(to_column)s"))
             # Add the SQL to our big list
-            column_sqls.append("%s %s" % (
+            column_sqls.append("{} {}".format(
                 self.quote_name(field.column),
                 definition,
             ))
@@ -814,7 +814,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             self.execute(statement, params=None)
 
     def delete_model(self, model):
-        super(DatabaseSchemaEditor, self).delete_model(model)
+        super().delete_model(model)
 
         # Also, drop sequence if exists
         table_name = model._meta.db_table
@@ -874,4 +874,4 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 except Exception as e:
                     raise e
         else:
-            super(DatabaseSchemaEditor, self).execute(sql, params)
+            super().execute(sql, params)


### PR DESCRIPTION
Django 3.2+ had different helper methods and this updates to that. Python 3.7+ updates also simplifies the code further and there are commits for that too. Also, update the readme to indicate Django 3.2+ is supported.


Authored-by: Vinit Kumar <vinit.kumar@kidskonnect.nl>
Signed-off-by: Vinit Kumar <vinit.kumar@kidskonnect.nl>